### PR TITLE
Ensure verifyRule uses correct spec file per test and improve logging

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -3,32 +3,27 @@ const fs = require('fs');
 const path = require('path');
 const { logger } = require('./logger');
 
-/**
-//  * Helper function that automatically extracts rule name from the calling test file
-//  * and runs the tests.
+/*
+  Helper function that automatically extracts rule name from the calling test file
+  and runs the tests.
+ 
+  @param {string} specFilePath - __filename from the spec file
+  @param {object} testCases - { valid: [], invalid: [] }
 */
-function verifyRule(testCases) {
-  const callerFile = module.parent && module.parent.filename ? module.parent.filename : __filename;
 
-  const base = path.basename(callerFile);
+function verifyRule(specFilePath, testCases) {
+  const specBaseName = path.basename(specFilePath);
+  const ruleName = specBaseName.replace(/\.spec\.js$/, '');
+  const rulePath = path.join(__dirname, '../rules', `${ruleName}.js`);
 
-  const ruleName = base.replace(/\.spec\.js$/, '');
-
-  _verifyRule(ruleName, testCases);
-}
-
-/**
- * Internal implementation: executes the rule test
- */
-function _verifyRule(ruleName, testCases) {
-  const rulePath = path.resolve(__dirname, `../rules/${ruleName}.js`);
-
-  if (fs.existsSync(rulePath)) {
-    const rule = require(rulePath);
-    RuleTester.verify(ruleName, rule, testCases);
-  } else {
-    logger.warn(`Skipped rule "${ruleName}": file not found at ${rulePath}`);
+  if (!fs.existsSync(rulePath)) {
+    logger.info(`Skipped test "${ruleName}": rule not found at ${rulePath}`);
+    return;
   }
+
+  const rule = require(rulePath);
+
+  RuleTester.verify(ruleName, rule, testCases);
 }
 
 function generateFragment(xmlString) {


### PR DESCRIPTION
Fixes #49 

### Testing

Test scenarios covered:
- Rules without tests: Detected and warned about rules that have no corresponding spec files.
- Tests without rules: Skipped any test files for which the corresponding rule implementation does not exist.
- Valid and invalid rule tests: Ran spec files for existing rules and verified both valid and invalid scenarios.

```
> @bp3/bpmnlint-plugin-bpmn-rules@set-by-pipeline-on-release test
> mocha test/check-coverage.spec.js test/**/*.spec.js

WARN: Rules without tests:
- activity-with-default-id
INFO: Skipped test "test1": rule not found at C:\Repos\bpmn-rules\rules\test1.js


  rules/escalation-with-default-name
    should lint valid
      ✔ test case #1 Process with valid escalation name
    should lint invalid
      ✔ test case #1 Process with default escalation name

  rules/signal-with-default-name
    should lint valid
      ✔ test case #1 Process with valid signal name
    should lint invalid
      ✔ test case #1 Process with default signal name


  4 passing (6ms)
```