### PR TITLE
Added log levels and removed helper warning from coverage test

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -15,20 +15,44 @@
 const chalk = require('chalk');
 const process = require('process');
 
+const LOG_LEVELS = {
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+function isStringNullOrEmpty(strValue) {
+  return strValue == null || strValue.toLowerCase() == '';
+}
+
+function isLogLevelEnabled(logLevel) {
+  return (
+    (!isStringNullOrEmpty(process.env.LOG_LEVEL) && Object.keys(LOG_LEVELS).includes(process.env.LOG_LEVEL.toLowerCase()) && LOG_LEVELS[process.env.LOG_LEVEL.toLowerCase()] <= logLevel) ||
+    (isStringNullOrEmpty(process.env.LOG_LEVEL) && LOG_LEVELS.info <= logLevel)
+  );
+}
+
 const logger = {
   debug: (...args) => {
-    if (process.env.VERBOSE != null && process.env.VERBOSE.toLowerCase() == 'true') {
+    if (isLogLevelEnabled(LOG_LEVELS.debug)) {
       console.log(chalk.gray('DEBUG:'), ...args);
     }
   },
   info: (...args) => {
-    console.log(chalk.blueBright.bold('INFO:'), ...args);
+    if (isLogLevelEnabled(LOG_LEVELS.info)) {
+      console.log(chalk.blueBright.bold('INFO:'), ...args);
+    }
   },
   warn: (...args) => {
-    console.warn(chalk.yellowBright.bold('WARN:'), ...args);
+    if (isLogLevelEnabled(LOG_LEVELS.warn)) {
+      console.warn(chalk.yellowBright.bold('WARN:'), ...args);
+    }
   },
   error: (...args) => {
-    console.error(chalk.redBright.bold('ERROR:'), ...args);
+    if (isLogLevelEnabled(LOG_LEVELS.error)) {
+      console.error(chalk.redBright.bold('ERROR:'), ...args);
+    }
   },
 };
 

--- a/test/check-coverage.spec.js
+++ b/test/check-coverage.spec.js
@@ -30,6 +30,7 @@ function checkRulesWithoutTests() {
   const ruleFiles = fs
     .readdirSync(rulesDir)
     .filter((file) => file.endsWith('.js'))
+    .filter((file) => !file.endsWith('helper.js'))
     .map((file) => file.replace('.js', ''));
 
   // Get all test files


### PR DESCRIPTION
This applies the log levels in the same way camunda-lint does, assuming an environment variable called LOG_LEVEL is set with one of the values:
- debug
- info
- warn
- error

Additionally, one of the helper files was getting flagged as missing tests when not supposed to have the same test as rules would.