### PR TITLE
New rule to check if versionTag is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ addRule('signal-with-default-name', { 'recommended-base': 'info', 'strict-base':
 addRule('subprocess-with-default-id', { 'recommended-base': 'info', 'strict-base': 'warn' });
 addRule('user-task-without-assignment-details', { 'recommended-base': 'warn', 'strict-base': 'error' });
 addRule('variable-name-with-invalid-character', { 'recommended-base': 'warn', 'strict-base': 'error' });
+addRule('version-tag-not-set', { 'recommended-base': 'off', 'strict-base': 'off' });
 
 logger.debug(`${name}: Setup version specific rulesets`);
 // Version Specific RECOMMENDED

--- a/rules/version-tag-not-set.js
+++ b/rules/version-tag-not-set.js
@@ -1,0 +1,44 @@
+/*================================================================================
+ =
+ = Licensed Materials - Property of BP3 Global
+ =
+ =  bpmnlint-plugin-bpmn-rules
+ =
+ = Copyright © BP3 Global Inc. 2026. All Rights Reserved.
+ = This software is subject to copyright protection under
+ = the laws of the United States, United Kingdom and other countries.
+ =
+ =================================================================================*/
+
+const { isAny, is } = require('bpmnlint-utils');
+
+const APPLICABLE_NODE_TYPES = ['bpmn:Process'];
+
+/**
+ * Rule that reports whether a process does not have a version tag set (applies to: Processes)
+ */
+module.exports = function () {
+  function check(node, reporter) {
+    if (!isAny(node, APPLICABLE_NODE_TYPES)) {
+      return;
+    }
+
+    const extensionElements = node.extensionElements;
+    let versionTagValue;
+
+    if (extensionElements && extensionElements.values) {
+      const versionTagElement = extensionElements.values.find((element) => is(element, 'zeebe:versionTag'));
+      versionTagValue = versionTagElement ? versionTagElement.value : undefined;
+    }
+
+    //output
+    if (!versionTagValue || !versionTagValue.trim()) {
+      reporter.report(node.id, 'Process does not have a version tag set. Please provide a significant version tag!');
+    }
+  }
+
+  return {
+    check: check,
+    appliesTo: APPLICABLE_NODE_TYPES,
+  };
+};

--- a/test/version-tag-not-set.spec.js
+++ b/test/version-tag-not-set.spec.js
@@ -1,0 +1,74 @@
+/*================================================================================
+ =
+ = Licensed Materials - Property of BP3 Global
+ =
+ =  bpmnlint-plugin-bpmn-rules
+ =
+ = Copyright © BP3 Global Inc. 2026. All Rights Reserved.
+ = This software is subject to copyright protection under
+ = the laws of the United States, United Kingdom and other countries.
+ =
+ =================================================================================*/
+
+const { createModdle } = require('bpmnlint/lib/testers/helper');
+const { verifyRule, generateFragment } = require('./helper');
+
+verifyRule(__filename, {
+  valid: [
+    {
+      name: 'Process with a version tag set',
+      moddleElement: createModdle(
+        generateFragment(
+          `
+<bpmn:process id="Process_1s1qrpb" name="Review Request Process">
+  <bpmn:extensionElements>
+    <zeebe:versionTag value="1.0.0" />
+  </bpmn:extensionElements>
+</bpmn:process>
+          `,
+          false
+        )
+      ),
+    },
+  ],
+  invalid: [
+    {
+      name: 'Process without a version tag element',
+      moddleElement: createModdle(
+        generateFragment(
+          `
+<bpmn:process id="Process_1s1qrpb" name="Review Request Process" />
+          `,
+          false
+        )
+      ),
+      report: [
+        {
+          id: 'Process_1s1qrpb',
+          message: 'Process does not have a version tag set. Please provide a significant version tag!',
+        },
+      ],
+    },
+    {
+      name: 'Process with an empty version tag value',
+      moddleElement: createModdle(
+        generateFragment(
+          `
+<bpmn:process id="Process_0empty1v" name="Review Request Process">
+  <bpmn:extensionElements>
+    <zeebe:versionTag value="" />
+  </bpmn:extensionElements>
+</bpmn:process>
+          `,
+          false
+        )
+      ),
+      report: [
+        {
+          id: 'Process_0empty1v',
+          message: 'Process does not have a version tag set. Please provide a significant version tag!',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This is the first time that I have asked Claude to create a brand new rule from scratch. But to my eye it looks pretty good. Not sure if anyone else can spot any problems with it.

What I really like is that it got added to the base version, so it will be available against all versions of the rules.